### PR TITLE
Add forecast interface to nwps

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,11 @@ Currently supported models are:
 - [x] [Pangu](https://arxiv.org/abs/2211.02556)
 - [x] [Fourcastnet](https://arxiv.org/abs/2202.11214) (v1 & v2)
 - [x] [DLWP](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2020MS002109)
+- [x] [ECMWF IFS (HRES)](https://www.ecmwf.int/en/forecasts/documentation-and-support/changes-ecmwf-model)
+- [x] [NOAA GFS](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast)
+- [ ] [ICON](https://www.dwd.de/EN/ourservices/nwp_forecast_data/nwp_forecast_data.html)
 - [ ] [Fuxi](https://www.nature.com/articles/s41612-023-00512-1)
-- [ ] [MetNet-3](https://arxiv.org/abs/2306.06079)
+- [ ] [Nano MetNet](https://arxiv.org/abs/2306.06079)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 Skyrim allows you to run any large weather model with a consumer grade GPU.
 
-Until very recently, weather forecasts were run in 100K+ CPU HPC clusters, solving massive numerical models. Within last 2 years, open-source foundation models trained on weather simulation datasets surpassed the skill level of these numerical models.
+Until very recently, weather forecasts were run in 100K+ CPU HPC clusters, solving massive numerical weather models (NWP). Within last 2 years, open-source foundation models trained on weather simulation datasets surpassed the skill level of these numerical models.
 
 Our goal is to make these models accessible by providing a well maintained infrastructure.
 
@@ -227,9 +227,9 @@ Currently supported models are:
 - [x] [Pangu](https://arxiv.org/abs/2211.02556)
 - [x] [Fourcastnet](https://arxiv.org/abs/2202.11214) (v1 & v2)
 - [x] [DLWP](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2020MS002109)
-- [x] [ECMWF IFS (HRES)](https://www.ecmwf.int/en/forecasts/documentation-and-support/changes-ecmwf-model)
-- [x] [NOAA GFS](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast)
-- [ ] [ICON](https://www.dwd.de/EN/ourservices/nwp_forecast_data/nwp_forecast_data.html)
+- [x] [(NWP) ECMWF IFS (HRES)](https://www.ecmwf.int/en/forecasts/documentation-and-support/changes-ecmwf-model) -- [notebook](https://github.com/secondlaw-ai/skyrim/blob/master/notebooks/02_ifs_model.ipynb)
+- [x] [(NWP) NOAA GFS](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast) -- [notebook](https://github.com/secondlaw-ai/skyrim/blob/master/notebooks/03_gfs_model.ipynb)
+- [ ] [(NWP) ICON](https://www.dwd.de/EN/ourservices/nwp_forecast_data/nwp_forecast_data.html)
 - [ ] [Fuxi](https://www.nature.com/articles/s41612-023-00512-1)
 - [ ] [Nano MetNet](https://arxiv.org/abs/2306.06079)
 

--- a/skyrim/libs/nwp/gfs.py
+++ b/skyrim/libs/nwp/gfs.py
@@ -257,6 +257,24 @@ class GFSModel:
 
         return exists
 
+    def forecast(
+        self,
+        start_time: datetime.datetime,
+        n_steps: int = 3,
+        step_size: int = 6,  # hours
+        **kwargs,
+    ) -> xr.DataArray:
+        # TODO: brittle, as it assumes steps described by step_size and n_steps are available
+
+        steps = [step_size * i for i in range(n_steps + 1)]
+
+        logger.debug(f"Forecast start time: {start_time}")
+        logger.debug(f"Forecast steps: {steps}")
+        logger.debug(f"len(steps): {len(steps)}")
+
+        darray = self.fetch_dataarray(start_time, steps)
+        return darray
+
     def predict(
         self,
         date: str,  # YYYMMDD, e.g. 20180101

--- a/skyrim/libs/nwp/gfs.py
+++ b/skyrim/libs/nwp/gfs.py
@@ -151,7 +151,7 @@ class GFSModel:
     GFS is a global model with a base horizontal resolution of 18 miles (28 kilometers)
     between grid points.
 
-    Temporal resolution covers analysis and forecasts out to 16 days.
+    Temporal resolution covers analysis and forecasts out to 16 days (384 hours).
 
     Horizontal resolution drops to 44 miles (70 kilometers) between grid points for forecasts
     between one week and two weeks.
@@ -279,7 +279,7 @@ class GFSModel:
         self,
         date: str,  # YYYMMDD, e.g. 20180101
         time: str,  # HHMM, e.g. 0300, 1400, etc
-        lead_time: int = 24,  # in hours 0-394,
+        lead_time: int = 24,  # in hours 0-384,
         save: bool = False,
         save_config: dict = {},
     ) -> xr.DataArray:

--- a/skyrim/libs/nwp/ifs.py
+++ b/skyrim/libs/nwp/ifs.py
@@ -125,7 +125,7 @@ class IFSModel:
     def assure_channels_exist(self, channels):
         for channel in channels:
             if channel not in IFS_Vocabulary.VOCAB.keys():
-                raise Exception(f'Channel {channel} does not exist in the vocabulary.')
+                raise Exception(f"Channel {channel} does not exist in the vocabulary.")
 
     @staticmethod
     def list_available_channels():
@@ -202,6 +202,24 @@ class IFSModel:
             return False
 
         return "KeyCount" in response and response["KeyCount"] > 0
+
+    def forecast(
+        self,
+        start_time: datetime.datetime,
+        n_steps: int = 3,
+        step_size: int = 6,  # hours
+        **kwargs,
+    ) -> xr.DataArray:
+        # TODO: brittle, as it assumes steps described by step_size and n_steps are available
+
+        steps = [step_size * i for i in range(n_steps + 1)]
+
+        logger.debug(f"Forecast start time: {start_time}")
+        logger.debug(f"Forecast steps: {steps}")
+        logger.debug(f"len(steps): {len(steps)}")
+
+        darray = self.fetch_dataarray(start_time, steps)
+        return darray
 
     def predict(
         self,


### PR DESCRIPTION
Required follow-up for #22 
* enable generating ifs/gfs datasets using `scripts/generate_dataset.py`
* add supported numerical weather models to README.md, i.e. IFS and GFS

```
from skyrim.libs.nwp import GFSModel
import datetime

start_time = datetime.datetime(2024,3,1)
channels = ["u10m", "v10m","u1000"]

gfs_model = GFSModel(channels=channels)
pred = gfs_model.forecast(start_time=start_time, n_steps= 5)
```