### PR TITLE
Feat/ens resolution

### DIFF
--- a/notebooks/05_cds_era5.ipynb
+++ b/notebooks/05_cds_era5.ipynb
@@ -1503,7 +1503,7 @@
     "fig, ax = plt.subplots(figsize=(10, 5)) \n",
     "ax.plot(t2m_akyaka.time.values, t2m_akyaka.values, \"--s\", label=\"ERA5\")\n",
     "ax.plot(t2m_akyaka_ifs.time.values, t2m_akyaka_ifs.values, \"--*\", label=\"IFS\")\n",
-    "ax.plot(t2m_akyaka_gfs.time.values, t2m_akyaka_gfs.values, \"--*\", label=\"GFS\")  # Use ax.plot\n",
+    "ax.plot(t2m_akyaka_gfs.time.values, t2m_akyaka_gfs.values, \"--*\", label=\"GFS\")  \n",
     "ax.legend()\n",
     "\n",
     "ax.set_xlabel(\"Time - UTC\")\n",
@@ -1511,9 +1511,7 @@
     "ax.set_title(\"Temperature Forecast Comparison\")\n",
     "plt.xticks(rotation=45)\n",
     "plt.grid()\n",
-    "plt.show()  \n",
-    "\n",
-    "# NOTE: it was a HOT day INDEED!"
+    "plt.show()  \n"
    ]
   },
   {
@@ -1573,7 +1571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/skyrim/libs/nwp/README.md
+++ b/skyrim/libs/nwp/README.md
@@ -1,0 +1,62 @@
+# ECMWF Forecasts S3 Structure
+
+This README provides information about the folder structure of ECMWF forecasts stored in the AWS S3 bucket `ecmwf-forecasts`.
+
+## Folder Structure Evolution
+
+The folder structure has evolved over time. Here's a breakdown of the changes:
+
+### Current Structure (2024-02-29 onwards)
+
+```
+s3://ecmwf-forecasts/<date>/<time>z/
+├── aifs/
+│   └── 0p25/
+│       └── oper/
+└── ifs/
+    ├── 0p25/
+    │   ├── enfo/
+    │   ├── oper/
+    │   ├── waef/
+    │   └── wave/
+    └── 0p4-beta/
+```
+
+### Intermediate Structure (2024-02-01 to 2024-02-28)
+
+```
+s3://ecmwf-forecasts/<date>/<time>z/
+├── 0p25/
+│   ├── enfo/
+│   ├── oper/
+│   ├── waef/
+│   └── wave/
+└── 0p4-beta/
+    ├── enfo/
+    ├── oper/
+    ├── waef/
+    └── wave/
+```
+
+### Previous Structure (2023-01-18 to 2024-01-31)
+
+```
+s3://ecmwf-forecasts/<date>/<time>z/
+└── 0p4-beta/
+    ├── enfo/
+    ├── oper/
+    ├── waef/
+    └── wave/
+```
+
+## Notes
+
+- `<date>` format: YYYYMMDD
+- `<time>` format: 00, 06, 12, 18
+- The bucket can be accessed without authentication using the `--no-sign` option with the AWS CLI.
+- The `aifs` folder contains the Artificial Intelligence/Integrated Forecasting System (AIFS), while the `ifs` folder contains the Integrated Forecasting System data.
+- Both `0p25` and `0p4-beta` resolutions contain the same set of subfolders: enfo, oper, waef, and wave.
+
+## Additional Information
+* [AIFS product specs](https://www.ecmwf.int/en/forecasts/dataset/aifs-machine-learning-data)
+    

--- a/skyrim/libs/nwp/ens.py
+++ b/skyrim/libs/nwp/ens.py
@@ -133,8 +133,6 @@ class ENSModel:
 
     """
 
-    LAT = np.linspace(90, -90, 721)
-    LON = np.linspace(0, 360, 1440, endpoint=False)
     MODEL_NAME = "ENS"
     VOCAB = ENS_Vocabulary.VOCAB
 
@@ -146,6 +144,7 @@ class ENSModel:
         cache: bool = True,
         multithread: bool = False,
         max_workers: int = 4,
+        resolution: Literal["0p25", "0p4-beta"] = "0p25",
     ):
         # TODO: add docstring!
         # TODO: check when the resolution of this product became 0.25
@@ -160,10 +159,17 @@ class ENSModel:
         self.model_name = "ENS"
 
         ensure_ecmwf_loaded()
-        self.client = ecmwf.opendata.Client(source=source)
+        self.client = ecmwf.opendata.Client(source=source, resol=resolution)
         logger.info(f"ENS model initialized with channels: {channels}")
         logger.info(f"member numbers: {numbers}")
         logger.debug(f"ENS Cache location: {self.cache}")
+
+        if resolution == "0p25":
+            self.LAT = np.linspace(90, -90, 721)
+            self.LON = np.linspace(0, 360, 1440, endpoint=False)
+        else:
+            self.LAT = np.linspace(90, -90, 451)
+            self.LON = np.linspace(0, 360, 900, endpoint=False)
 
     def assure_channels_exist(self, channels):
         for channel in channels:

--- a/skyrim/libs/nwp/ens.py
+++ b/skyrim/libs/nwp/ens.py
@@ -2,7 +2,6 @@
 TODO:
 - [ ] Add support to check if the forecast is available before downloading.
 - [ ] Add "snipe" method to fetch all available forecasts for a given date and time. 
-- [ ] Add info about ENS resolution changes
 
 NOTE: 
 When downloaded from opendata: 

--- a/skyrim/libs/nwp/ifs.py
+++ b/skyrim/libs/nwp/ifs.py
@@ -119,6 +119,8 @@ class IFSModel:
     Additional resources:
         Known IFS forecasting issues:
         https://confluence.ecmwf.int/display/FCST/Known+IFS+forecasting+issues
+
+    # TODO: add info about the availability of different resolutions
     """
 
     IFS_BUCKET_NAME = "ecmwf-forecasts"


### PR DESCRIPTION
This pull request includes updates to the `notebooks/05_cds_era5.ipynb` file, enhancements to the `ENSModel` class in `skyrim/libs/nwp/ens.py`, and documentation improvements in the `skyrim/libs/nwp/README.md` file. The most important changes are detailed below:

### Enhancements to `ENSModel` class:

* Added a `resolution` parameter to the `__init__` method to support different forecast resolutions (`0p25` and `0p4-beta`). The `LAT` and `LON` attributes are now set based on the resolution. (`skyrim/libs/nwp/ens.py`) [[1]](diffhunk://#diff-e0cde4cad1cf2af8ede60aedf408ea4c072d1ff656bd503f6a9f658b25aafc2eR146) [[2]](diffhunk://#diff-e0cde4cad1cf2af8ede60aedf408ea4c072d1ff656bd503f6a9f658b25aafc2eL163-R172)
* Removed hardcoded `LAT` and `LON` definitions from the class body. (`skyrim/libs/nwp/ens.py`)

### Documentation improvements:

* Added a detailed README file for the ECMWF forecasts S3 structure, including the evolution of folder structures over time. (`skyrim/libs/nwp/README.md`)

### Minor updates:

* Removed unnecessary comments and notes from the notebook and updated the Python version metadata. (`notebooks/05_cds_era5.ipynb`) [[1]](diffhunk://#diff-e6fe77f5384388475ff45e477e833de554222c845d7cb0f7bbbd46b8e11b3572L1506-R1514) [[2]](diffhunk://#diff-e6fe77f5384388475ff45e477e833de554222c845d7cb0f7bbbd46b8e11b3572L1576-R1574)
* Added a TODO note in the `IFSModel` class regarding the availability of different resolutions. (`skyrim/libs/nwp/ifs.py`)

### Quick Example
```
import datetime
from skyrim.libs.nwp import ENSModel
start_time = datetime.datetime(2024, 2, 1)
channels = ["u10m"]
numbers = [0, 1]
model = ENSModel(channels, numbers, resolution="0p4-beta", cache=False)
output = model.forecast(start_time=start_time, n_steps=3, step_size=6)
print(output.shape, output.dims)

>> (2, 4, 1, 451, 900) ('number', 'time', 'channel', 'lat', 'lon')
```